### PR TITLE
babel: ignore .babelrc files

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ function es2040 (filename, options) {
         plugins: preset.plugins,
         sourceMaps: options._flags.debug ? 'inline' : false,
         filename: filename,
-        compact: false
+        compact: false,
+        babelrc: false
       })
     } catch (err) {
       this.emit('error', err)


### PR DESCRIPTION
fixes an error caused by a dependency having a babelrc file

```
{ ReferenceError: Unknown plugin "transform-runtime" specified in "/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/stilr/.babelrc" at 0, attempted to resolve relative to "/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/stilr" while parsing file: /home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/stilr/dist/index.js
    at /home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/babel-core/lib/transformation/file/options/option-manager.js:180:17
    at Array.map (native)
    at Function.normalisePlugins (/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/babel-core/lib/transformation/file/options/option-manager.js:158:20)
    at OptionManager.mergeOptions (/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/babel-core/lib/transformation/file/options/option-manager.js:234:36)
    at OptionManager.init (/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/babel-core/lib/transformation/file/index.js:216:65)
    at new File (/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/babel-core/lib/transformation/file/index.js:139:24)
    at Pipeline.transform (/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at DestroyableTransform.end [as _flush] (/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/es2040/index.js:23:23)
    at DestroyableTransform.<anonymous> (/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/readable-stream/lib/_stream_transform.js:115:49)
  filename: '/home/dinosaur/repos/enspiral-root-systems/cobuy/node_modules/stilr/dist/index.js',
```